### PR TITLE
Add mirror for the pre-trained model

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -14,3 +14,9 @@ pip install git+https://github.com/lanpa/tensorboardX
 # Download pre-trained model
 pip install gdown
 gdown https://drive.google.com/uc?id=1LC5iVcvgksQhNVJ-CbMigqXnPAaquiA2
+
+# If you get a "Too many users have viewed or downloaded this file recently." error, 
+# run the following 3 lines to download pre-trained model from a mirror:
+# pip install internetarchive
+# ia download neuraladobe-ucsdparser
+# mv neuraladobe-ucsdparser/best_parser.pt .


### PR DESCRIPTION
If one uses `gdown` more than ~20 times within 24 hours, we get the error:

> Access denied with the following error:

>         Too many users have viewed or downloaded this file recently. Please
        try accessing the file again later. If the file you are trying to
        access is particularly large or is shared with many people, it may
        take up to 24 hours to be able to view or download the file. If you
        still can't access a file after 24 hours, contact your domain
        administrator.

> You may still be able to access the file from the browser:

>         https://drive.google.com/uc?id=1LC5iVcvgksQhNVJ-CbMigqXnPAaquiA2

so I mirror the file on https://archive.org/details/neuraladobe-ucsdparser